### PR TITLE
Make compilation work with OpenCV 3

### DIFF
--- a/src/multitexturer.cpp
+++ b/src/multitexturer.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 
 #include <opencv2/photo/photo.hpp>
+#include <opencv2/opencv.hpp>
 
 #include "multitexturer.h"
 


### PR DESCRIPTION
With OpenCV 3, it was not sufficient to include opencv2/photo/photo.hpp to make it compile. I included  opencv2/opencv.hpp as otherwise it was complaining about not knowing about imread, CascadeClassifier, etc. 